### PR TITLE
correcting a dependency bug

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,9 +1,9 @@
 var config = {};
 
 config.server = {
-    host: 'orionlive.fiware.org',
-    port: 60001,
-    path: '/arduino'
+    host: 'leshan.eclipse.org',
+    port: 5683,
+    path: '/'
 };
 
 config.client = {

--- a/lwm2m-arduino.js
+++ b/lwm2m-arduino.js
@@ -1,5 +1,5 @@
 var five = require("johnny-five"),
-    lwm2mClient = require('iotagent-lwm2m-lib').client,
+    lwm2mClient = require('lwm2m-node-lib').client,
     async = require('async'),
     apply = async.apply,
     config = require('./config'),
@@ -69,6 +69,8 @@ function createDataHandler(analogUri, i, transform) {
 }
 
 board.on('ready', function() {
+    lwm2mClient.init(config);
+    
     var analogUri = '/' + config.mapping.objectType + '/' + config.mapping.analogInstance,
         digitalUri = '/' + config.mapping.objectType + '/' + config.mapping.digitalInstance,
         connectionFlow = [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "firmata": "0.3.1",
     "logops": "*",
     "async": "*",
-    "iotagent-lwm2m-lib": "https://github.com/telefonicaid/iotagent-lwm2m-lib/tarball/develop"
+    "lwm2m-node-lib": "https://github.com/telefonicaid/lwm2m-node-lib/tarball/develop"
   },
   "author": "",
   "license": "AGPL"


### PR DESCRIPTION
The iotagent-lwm2m-lib repository seems to have changed to lwm2m-node-lib. The `npm install` command didn't work because of that. It seems that npm doesn't work well with redirections.
